### PR TITLE
SNAP-66 add default data DatePicker

### DIFF
--- a/src/widget/generalInformation/generalInfoForms/ui/GeneralInfoForms.tsx
+++ b/src/widget/generalInformation/generalInfoForms/ui/GeneralInfoForms.tsx
@@ -93,7 +93,7 @@ export const GeneralInfoForms = memo((props: PersonalInfoProps) => {
                       error={!!errors.dateOfBirth}
                       name={'dateOfBirth'}
                       onChange={(newValue) => onChange(newValue)}
-                      value={value}
+                      value={value ? value : new Date('2000-01-01T00:00:00.000Z').toISOString()}
                     />
                   )}
                   control={control}


### PR DESCRIPTION
добавил дефолтную дату в DatePicker, чтобы не было бага, когда вместо даты передаем null